### PR TITLE
fix: Get class name from dynamic variable

### DIFF
--- a/src/Extensions/BaseElementCMSEditLinkExtension.php
+++ b/src/Extensions/BaseElementCMSEditLinkExtension.php
@@ -170,7 +170,7 @@ class BaseElementCMSEditLinkExtension extends Extension
 		if (!empty($page))
 		{
 			/** Grab the class and check it - is it a column block? */
-			$pageClass 	= $page::class;
+			$pageClass 	= get_class($page);
 
 			if ($pageClass == ColumnBlock::class)
 			{


### PR DESCRIPTION
Call PHP in built ```get_class($var)``` instead of ```$var::class```.